### PR TITLE
Windows fullscreen fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 /presentation
 
 /.vscode
+slides/

--- a/manim_presentation/present.py
+++ b/manim_presentation/present.py
@@ -8,6 +8,9 @@ import time
 import argparse
 from enum import Enum
 import platform
+import ctypes
+
+
 
 class Config:
     @classmethod
@@ -176,7 +179,7 @@ class Display:
         self.last_time = now()
 
         if fullscreen:
-            cv2.namedWindow("Video", cv2.WND_PROP_FULLSCREEN)
+            cv2.namedWindow("Video", cv2.WINDOW_FREERATIO)
             cv2.setWindowProperty("Video", cv2.WND_PROP_FULLSCREEN, cv2.WINDOW_FULLSCREEN)
     
     @property
@@ -203,7 +206,27 @@ class Display:
     def show_video(self):
         self.lag = now() - self.last_time
         self.last_time = now()
-        cv2.imshow("Video", self.lastframe) 
+
+        frame = self.lastframe
+
+        if platform.system() == "Windows":
+            user32 = ctypes.windll.user32
+            screen_width, screen_height = user32.GetSystemMetrics(0), user32.GetSystemMetrics(1)
+             
+            frame_height, frame_width, _ = frame.shape
+
+            scaleWidth = float(screen_width)/float(frame_width)
+            scaleHeight = float(screen_height)/float(frame_height)
+
+            if scaleHeight>scaleWidth:
+                imgScale = scaleWidth
+            else:
+                imgScale = scaleHeight
+
+            newX,newY = frame.shape[1]*imgScale, frame.shape[0]*imgScale
+            frame = cv2.resize(frame,(int(newX),int(newY)))
+
+        cv2.imshow("Video", frame) 
 
     def show_info(self):
         info = np.zeros((130, 420), np.uint8)


### PR DESCRIPTION
This proposes a small fix to the problem where full-screen resolution is bad. Apparently, this only occurs in Windows platforms.
Tested on Windows 10 & Ubuntu 22.04. The solution is mostly a copy / paste from [here](https://www.alirookie.com/post/python-opencv-fullscreen-webcam-video-improve-image-quality).

Even though, the fix is not a perfect fix and quality is still not as good as with Ubuntu. For instance, I had to render in `p` or even `k` quality on Windows to have a result similar to `h` quality on Ubuntu.

As mentioned in #15, I am working on a separate fork on which I did other improvements, and many more improvements are still ongoing. Maybe we could merge both works later, or I can keep me work separate as it implies some major changes in the codebase.
Anyway, this is not the point of this PR :-)

Closes #15.